### PR TITLE
Improve transcription quality and add Whisper tuning UI

### DIFF
--- a/liveTranscribe/Form1.Designer.cs
+++ b/liveTranscribe/Form1.Designer.cs
@@ -30,66 +30,366 @@
         {
             components = new System.ComponentModel.Container();
             notifyIcon1 = new NotifyIcon(components);
-            button1 = new Button();
-            button2 = new Button();
-            label1 = new Label();
-            label2 = new Label();
+            startButton = new Button();
+            stopButton = new Button();
+            statusLabel = new Label();
+            transcriptTextBox = new TextBox();
+            modelGroupBox = new GroupBox();
+            modelComboBox = new ComboBox();
+            modelLabel = new Label();
+            languageGroupBox = new GroupBox();
+            translateCheckBox = new CheckBox();
+            languageComboBox = new ComboBox();
+            autoDetectLanguageCheckBox = new CheckBox();
+            samplingGroupBox = new GroupBox();
+            patienceLabel = new Label();
+            patienceNumericUpDown = new NumericUpDown();
+            beamSizeNumericUpDown = new NumericUpDown();
+            beamSizeLabel = new Label();
+            bestOfNumericUpDown = new NumericUpDown();
+            bestOfLabel = new Label();
+            beamSearchRadioButton = new RadioButton();
+            greedyRadioButton = new RadioButton();
+            advancedGroupBox = new GroupBox();
+            logProbNumericUpDown = new NumericUpDown();
+            logProbLabel = new Label();
+            noSpeechNumericUpDown = new NumericUpDown();
+            noSpeechLabel = new Label();
+            temperatureNumericUpDown = new NumericUpDown();
+            temperatureLabel = new Label();
+            ((System.ComponentModel.ISupportInitialize)patienceNumericUpDown).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)beamSizeNumericUpDown).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)bestOfNumericUpDown).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)logProbNumericUpDown).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)noSpeechNumericUpDown).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)temperatureNumericUpDown).BeginInit();
             SuspendLayout();
-            // 
+            //
             // notifyIcon1
-            // 
-            notifyIcon1.Text = "notifyIcon1";
+            //
+            notifyIcon1.Text = "liveTranscribe";
             notifyIcon1.Visible = true;
-            // 
-            // button1
-            // 
-            button1.Location = new Point(309, 156);
-            button1.Name = "button1";
-            button1.Size = new Size(75, 23);
-            button1.TabIndex = 0;
-            button1.Text = "button1";
-            button1.UseVisualStyleBackColor = true;
-            button1.Click += button1_Click;
-            // 
-            // button2
-            // 
-            button2.Location = new Point(420, 234);
-            button2.Name = "button2";
-            button2.Size = new Size(75, 23);
-            button2.TabIndex = 1;
-            button2.Text = "button2";
-            button2.UseVisualStyleBackColor = true;
-            button2.Click += button2_Click;
-            // 
-            // label1
-            // 
-            label1.AutoSize = true;
-            label1.Location = new Point(167, 33);
-            label1.Name = "label1";
-            label1.Size = new Size(38, 15);
-            label1.TabIndex = 2;
-            label1.Text = "label1";
-            // 
-            // label2
-            // 
-            label2.AutoSize = true;
-            label2.Location = new Point(167, 65);
-            label2.Name = "label2";
-            label2.Size = new Size(38, 15);
-            label2.TabIndex = 3;
-            label2.Text = "label2";
-            // 
+            //
+            // startButton
+            //
+            startButton.Location = new Point(20, 20);
+            startButton.Name = "startButton";
+            startButton.Size = new Size(140, 30);
+            startButton.TabIndex = 0;
+            startButton.Text = "Start Listening";
+            startButton.UseVisualStyleBackColor = true;
+            startButton.Click += startButton_Click;
+            //
+            // stopButton
+            //
+            stopButton.Enabled = false;
+            stopButton.Location = new Point(170, 20);
+            stopButton.Name = "stopButton";
+            stopButton.Size = new Size(140, 30);
+            stopButton.TabIndex = 1;
+            stopButton.Text = "Stop";
+            stopButton.UseVisualStyleBackColor = true;
+            stopButton.Click += stopButton_Click;
+            //
+            // statusLabel
+            //
+            statusLabel.AutoSize = true;
+            statusLabel.Location = new Point(20, 60);
+            statusLabel.Name = "statusLabel";
+            statusLabel.Size = new Size(81, 15);
+            statusLabel.TabIndex = 2;
+            statusLabel.Text = "Status: Ready";
+            //
+            // transcriptTextBox
+            //
+            transcriptTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
+            transcriptTextBox.Font = new Font("Consolas", 10F, FontStyle.Regular, GraphicsUnit.Point);
+            transcriptTextBox.Location = new Point(20, 90);
+            transcriptTextBox.Multiline = true;
+            transcriptTextBox.Name = "transcriptTextBox";
+            transcriptTextBox.ReadOnly = true;
+            transcriptTextBox.ScrollBars = ScrollBars.Vertical;
+            transcriptTextBox.Size = new Size(540, 400);
+            transcriptTextBox.TabIndex = 3;
+            //
+            // modelGroupBox
+            //
+            modelGroupBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            modelGroupBox.Controls.Add(modelComboBox);
+            modelGroupBox.Controls.Add(modelLabel);
+            modelGroupBox.Location = new Point(580, 20);
+            modelGroupBox.Name = "modelGroupBox";
+            modelGroupBox.Size = new Size(280, 85);
+            modelGroupBox.TabIndex = 4;
+            modelGroupBox.TabStop = false;
+            modelGroupBox.Text = "Model";
+            //
+            // modelComboBox
+            //
+            modelComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            modelComboBox.FormattingEnabled = true;
+            modelComboBox.Location = new Point(20, 45);
+            modelComboBox.Name = "modelComboBox";
+            modelComboBox.Size = new Size(240, 23);
+            modelComboBox.TabIndex = 1;
+            //
+            // modelLabel
+            //
+            modelLabel.AutoSize = true;
+            modelLabel.Location = new Point(20, 25);
+            modelLabel.Name = "modelLabel";
+            modelLabel.Size = new Size(123, 15);
+            modelLabel.TabIndex = 0;
+            modelLabel.Text = "Select Whisper Model";
+            //
+            // languageGroupBox
+            //
+            languageGroupBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            languageGroupBox.Controls.Add(translateCheckBox);
+            languageGroupBox.Controls.Add(languageComboBox);
+            languageGroupBox.Controls.Add(autoDetectLanguageCheckBox);
+            languageGroupBox.Location = new Point(580, 115);
+            languageGroupBox.Name = "languageGroupBox";
+            languageGroupBox.Size = new Size(280, 135);
+            languageGroupBox.TabIndex = 5;
+            languageGroupBox.TabStop = false;
+            languageGroupBox.Text = "Language";
+            //
+            // translateCheckBox
+            //
+            translateCheckBox.AutoSize = true;
+            translateCheckBox.Location = new Point(20, 100);
+            translateCheckBox.Name = "translateCheckBox";
+            translateCheckBox.Size = new Size(189, 19);
+            translateCheckBox.TabIndex = 2;
+            translateCheckBox.Text = "Translate to English (if able)";
+            translateCheckBox.UseVisualStyleBackColor = true;
+            //
+            // languageComboBox
+            //
+            languageComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            languageComboBox.FormattingEnabled = true;
+            languageComboBox.Location = new Point(20, 65);
+            languageComboBox.Name = "languageComboBox";
+            languageComboBox.Size = new Size(240, 23);
+            languageComboBox.TabIndex = 1;
+            //
+            // autoDetectLanguageCheckBox
+            //
+            autoDetectLanguageCheckBox.AutoSize = true;
+            autoDetectLanguageCheckBox.Checked = true;
+            autoDetectLanguageCheckBox.CheckState = CheckState.Checked;
+            autoDetectLanguageCheckBox.Location = new Point(20, 30);
+            autoDetectLanguageCheckBox.Name = "autoDetectLanguageCheckBox";
+            autoDetectLanguageCheckBox.Size = new Size(130, 19);
+            autoDetectLanguageCheckBox.TabIndex = 0;
+            autoDetectLanguageCheckBox.Text = "Auto detect once";
+            autoDetectLanguageCheckBox.UseVisualStyleBackColor = true;
+            autoDetectLanguageCheckBox.CheckedChanged += autoDetectLanguageCheckBox_CheckedChanged;
+            //
+            // samplingGroupBox
+            //
+            samplingGroupBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            samplingGroupBox.Controls.Add(patienceLabel);
+            samplingGroupBox.Controls.Add(patienceNumericUpDown);
+            samplingGroupBox.Controls.Add(beamSizeNumericUpDown);
+            samplingGroupBox.Controls.Add(beamSizeLabel);
+            samplingGroupBox.Controls.Add(bestOfNumericUpDown);
+            samplingGroupBox.Controls.Add(bestOfLabel);
+            samplingGroupBox.Controls.Add(beamSearchRadioButton);
+            samplingGroupBox.Controls.Add(greedyRadioButton);
+            samplingGroupBox.Location = new Point(580, 260);
+            samplingGroupBox.Name = "samplingGroupBox";
+            samplingGroupBox.Size = new Size(280, 160);
+            samplingGroupBox.TabIndex = 6;
+            samplingGroupBox.TabStop = false;
+            samplingGroupBox.Text = "Sampling";
+            //
+            // patienceLabel
+            //
+            patienceLabel.AutoSize = true;
+            patienceLabel.Location = new Point(40, 120);
+            patienceLabel.Name = "patienceLabel";
+            patienceLabel.Size = new Size(53, 15);
+            patienceLabel.TabIndex = 6;
+            patienceLabel.Text = "Patience";
+            //
+            // patienceNumericUpDown
+            //
+            patienceNumericUpDown.DecimalPlaces = 2;
+            patienceNumericUpDown.Enabled = false;
+            patienceNumericUpDown.Increment = new decimal(new int[] { 5, 0, 0, 131072 });
+            patienceNumericUpDown.Location = new Point(160, 118);
+            patienceNumericUpDown.Maximum = 3m;
+            patienceNumericUpDown.Minimum = 0.1m;
+            patienceNumericUpDown.Name = "patienceNumericUpDown";
+            patienceNumericUpDown.Size = new Size(100, 23);
+            patienceNumericUpDown.TabIndex = 7;
+            patienceNumericUpDown.Value = 1m;
+            //
+            // beamSizeNumericUpDown
+            //
+            beamSizeNumericUpDown.Enabled = false;
+            beamSizeNumericUpDown.Location = new Point(160, 89);
+            beamSizeNumericUpDown.Maximum = 10m;
+            beamSizeNumericUpDown.Minimum = 1m;
+            beamSizeNumericUpDown.Name = "beamSizeNumericUpDown";
+            beamSizeNumericUpDown.Size = new Size(100, 23);
+            beamSizeNumericUpDown.TabIndex = 5;
+            beamSizeNumericUpDown.Value = new decimal(new int[] { 5, 0, 0, 0 });
+            //
+            // beamSizeLabel
+            //
+            beamSizeLabel.AutoSize = true;
+            beamSizeLabel.Location = new Point(40, 91);
+            beamSizeLabel.Name = "beamSizeLabel";
+            beamSizeLabel.Size = new Size(86, 15);
+            beamSizeLabel.TabIndex = 4;
+            beamSizeLabel.Text = "Beam size (β)";
+            //
+            // bestOfNumericUpDown
+            //
+            bestOfNumericUpDown.Location = new Point(160, 60);
+            bestOfNumericUpDown.Maximum = 10m;
+            bestOfNumericUpDown.Minimum = 1m;
+            bestOfNumericUpDown.Name = "bestOfNumericUpDown";
+            bestOfNumericUpDown.Size = new Size(100, 23);
+            bestOfNumericUpDown.TabIndex = 3;
+            bestOfNumericUpDown.Value = new decimal(new int[] { 5, 0, 0, 0 });
+            //
+            // bestOfLabel
+            //
+            bestOfLabel.AutoSize = true;
+            bestOfLabel.Location = new Point(40, 62);
+            bestOfLabel.Name = "bestOfLabel";
+            bestOfLabel.Size = new Size(82, 15);
+            bestOfLabel.TabIndex = 2;
+            bestOfLabel.Text = "Best of (γ)";
+            //
+            // beamSearchRadioButton
+            //
+            beamSearchRadioButton.AutoSize = true;
+            beamSearchRadioButton.Location = new Point(20, 94);
+            beamSearchRadioButton.Name = "beamSearchRadioButton";
+            beamSearchRadioButton.Size = new Size(138, 19);
+            beamSearchRadioButton.TabIndex = 1;
+            beamSearchRadioButton.Text = "Beam search (β, ρ)";
+            beamSearchRadioButton.UseVisualStyleBackColor = true;
+            beamSearchRadioButton.CheckedChanged += samplingRadioButton_CheckedChanged;
+            //
+            // greedyRadioButton
+            //
+            greedyRadioButton.AutoSize = true;
+            greedyRadioButton.Checked = true;
+            greedyRadioButton.Location = new Point(20, 34);
+            greedyRadioButton.Name = "greedyRadioButton";
+            greedyRadioButton.Size = new Size(141, 19);
+            greedyRadioButton.TabIndex = 0;
+            greedyRadioButton.TabStop = true;
+            greedyRadioButton.Text = "Greedy (best-of γ)";
+            greedyRadioButton.UseVisualStyleBackColor = true;
+            greedyRadioButton.CheckedChanged += samplingRadioButton_CheckedChanged;
+            //
+            // advancedGroupBox
+            //
+            advancedGroupBox.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            advancedGroupBox.Controls.Add(logProbNumericUpDown);
+            advancedGroupBox.Controls.Add(logProbLabel);
+            advancedGroupBox.Controls.Add(noSpeechNumericUpDown);
+            advancedGroupBox.Controls.Add(noSpeechLabel);
+            advancedGroupBox.Controls.Add(temperatureNumericUpDown);
+            advancedGroupBox.Controls.Add(temperatureLabel);
+            advancedGroupBox.Location = new Point(580, 430);
+            advancedGroupBox.Name = "advancedGroupBox";
+            advancedGroupBox.Size = new Size(280, 120);
+            advancedGroupBox.TabIndex = 7;
+            advancedGroupBox.TabStop = false;
+            advancedGroupBox.Text = "Advanced";
+            //
+            // logProbNumericUpDown
+            //
+            logProbNumericUpDown.DecimalPlaces = 2;
+            logProbNumericUpDown.Increment = new decimal(new int[] { 5, 0, 0, 131072 });
+            logProbNumericUpDown.Location = new Point(160, 85);
+            logProbNumericUpDown.Maximum = 0m;
+            logProbNumericUpDown.Minimum = -5m;
+            logProbNumericUpDown.Name = "logProbNumericUpDown";
+            logProbNumericUpDown.Size = new Size(100, 23);
+            logProbNumericUpDown.TabIndex = 5;
+            logProbNumericUpDown.Value = -1m;
+            //
+            // logProbLabel
+            //
+            logProbLabel.AutoSize = true;
+            logProbLabel.Location = new Point(20, 87);
+            logProbLabel.Name = "logProbLabel";
+            logProbLabel.Size = new Size(121, 15);
+            logProbLabel.TabIndex = 4;
+            logProbLabel.Text = "Log prob threshold";
+            //
+            // noSpeechNumericUpDown
+            //
+            noSpeechNumericUpDown.DecimalPlaces = 2;
+            noSpeechNumericUpDown.Increment = new decimal(new int[] { 5, 0, 0, 131072 });
+            noSpeechNumericUpDown.Location = new Point(160, 55);
+            noSpeechNumericUpDown.Maximum = 1m;
+            noSpeechNumericUpDown.Minimum = 0m;
+            noSpeechNumericUpDown.Name = "noSpeechNumericUpDown";
+            noSpeechNumericUpDown.Size = new Size(100, 23);
+            noSpeechNumericUpDown.TabIndex = 3;
+            noSpeechNumericUpDown.Value = 0.6m;
+            //
+            // noSpeechLabel
+            //
+            noSpeechLabel.AutoSize = true;
+            noSpeechLabel.Location = new Point(20, 57);
+            noSpeechLabel.Name = "noSpeechLabel";
+            noSpeechLabel.Size = new Size(112, 15);
+            noSpeechLabel.TabIndex = 2;
+            noSpeechLabel.Text = "No speech threshold";
+            //
+            // temperatureNumericUpDown
+            //
+            temperatureNumericUpDown.DecimalPlaces = 2;
+            temperatureNumericUpDown.Increment = new decimal(new int[] { 5, 0, 0, 131072 });
+            temperatureNumericUpDown.Location = new Point(160, 25);
+            temperatureNumericUpDown.Maximum = 1m;
+            temperatureNumericUpDown.Minimum = 0m;
+            temperatureNumericUpDown.Name = "temperatureNumericUpDown";
+            temperatureNumericUpDown.Size = new Size(100, 23);
+            temperatureNumericUpDown.TabIndex = 1;
+            temperatureNumericUpDown.Value = 0.2m;
+            //
+            // temperatureLabel
+            //
+            temperatureLabel.AutoSize = true;
+            temperatureLabel.Location = new Point(20, 27);
+            temperatureLabel.Name = "temperatureLabel";
+            temperatureLabel.Size = new Size(73, 15);
+            temperatureLabel.TabIndex = 0;
+            temperatureLabel.Text = "Temperature";
+            //
             // Form1
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(800, 450);
-            Controls.Add(label2);
-            Controls.Add(label1);
-            Controls.Add(button2);
-            Controls.Add(button1);
+            ClientSize = new Size(884, 571);
+            Controls.Add(advancedGroupBox);
+            Controls.Add(samplingGroupBox);
+            Controls.Add(languageGroupBox);
+            Controls.Add(modelGroupBox);
+            Controls.Add(transcriptTextBox);
+            Controls.Add(statusLabel);
+            Controls.Add(stopButton);
+            Controls.Add(startButton);
             Name = "Form1";
-            Text = "Form1";
+            Text = "Live Transcribe";
+            ((System.ComponentModel.ISupportInitialize)patienceNumericUpDown).EndInit();
+            ((System.ComponentModel.ISupportInitialize)beamSizeNumericUpDown).EndInit();
+            ((System.ComponentModel.ISupportInitialize)bestOfNumericUpDown).EndInit();
+            ((System.ComponentModel.ISupportInitialize)logProbNumericUpDown).EndInit();
+            ((System.ComponentModel.ISupportInitialize)noSpeechNumericUpDown).EndInit();
+            ((System.ComponentModel.ISupportInitialize)temperatureNumericUpDown).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -97,9 +397,32 @@
         #endregion
 
         private NotifyIcon notifyIcon1;
-        private Button button1;
-        private Button button2;
-        private Label label1;
-        private Label label2;
+        private Button startButton;
+        private Button stopButton;
+        private Label statusLabel;
+        private TextBox transcriptTextBox;
+        private GroupBox modelGroupBox;
+        private ComboBox modelComboBox;
+        private Label modelLabel;
+        private GroupBox languageGroupBox;
+        private CheckBox translateCheckBox;
+        private ComboBox languageComboBox;
+        private CheckBox autoDetectLanguageCheckBox;
+        private GroupBox samplingGroupBox;
+        private Label patienceLabel;
+        private NumericUpDown patienceNumericUpDown;
+        private NumericUpDown beamSizeNumericUpDown;
+        private Label beamSizeLabel;
+        private NumericUpDown bestOfNumericUpDown;
+        private Label bestOfLabel;
+        private RadioButton beamSearchRadioButton;
+        private RadioButton greedyRadioButton;
+        private GroupBox advancedGroupBox;
+        private NumericUpDown logProbNumericUpDown;
+        private Label logProbLabel;
+        private NumericUpDown noSpeechNumericUpDown;
+        private Label noSpeechLabel;
+        private NumericUpDown temperatureNumericUpDown;
+        private Label temperatureLabel;
     }
 }

--- a/liveTranscribe/Form1.cs
+++ b/liveTranscribe/Form1.cs
@@ -1,142 +1,407 @@
-using EchoSharp.Abstractions.Audio;
 using EchoSharp.Abstractions.SpeechTranscription;
-using EchoSharp.NAudio;
 using EchoSharp.Onnx.SileroVad;
 using EchoSharp.SpeechTranscription;
 using EchoSharp.Whisper.net;
-using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
-using NAudio.Wave;
-using NAudio.Wave.SampleProviders;
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using Whisper.net;
 using Whisper.net.Ggml;
-using Whisper.net.LibraryLoader;
+
 namespace liveTranscribe
 {
     public partial class Form1 : Form
     {
-        WaspiLoopbackAudioSource waveloop;
-        Task showTranscriptTask;
-        Task LoadTask;
-        private IRealtimeSpeechTranscriptor realTimeTranscriptor;
-        private SileroVadDetectorFactory vadDetectorFactory;
-        private WhisperFactory factory;
-        private WhisperSpeechTranscriptorFactory speechTranscriptorFactory;
-        private EchoSharpRealtimeTranscriptorFactory realTimeFactory;
-        CancellationTokenSource token = new CancellationTokenSource();
+        private static readonly Uri SileroVadUri = new("https://github.com/sandrohanea/silero-vad/raw/refs/tags/v1/src/silero_vad/data/silero_vad.onnx");
+        private static readonly string ModelsDirectory = Path.Combine(AppContext.BaseDirectory, "models");
+
+        private readonly List<ModelOption> modelOptions = new()
+        {
+            new ModelOption("Tiny (fastest, lowest quality)", GgmlType.Tiny, "ggml-Tiny.bin"),
+            new ModelOption("Base", GgmlType.Base, "ggml-Base.bin"),
+            new ModelOption("Small", GgmlType.Small, "ggml-Small.bin"),
+            new ModelOption("Medium (default)", GgmlType.Medium, "ggml-Medium.bin"),
+            new ModelOption("Large V3 (highest quality)", GgmlType.LargeV3, "ggml-LargeV3.bin")
+        };
+
+        private readonly List<LanguageOption> languageOptions = new()
+        {
+            new LanguageOption("English (United States)", new CultureInfo("en-US")),
+            new LanguageOption("English (United Kingdom)", new CultureInfo("en-GB")),
+            new LanguageOption("Spanish (Spain)", new CultureInfo("es-ES")),
+            new LanguageOption("Spanish (Latin America)", new CultureInfo("es-MX")),
+            new LanguageOption("French", new CultureInfo("fr-FR")),
+            new LanguageOption("German", new CultureInfo("de-DE")),
+            new LanguageOption("Italian", new CultureInfo("it-IT")),
+            new LanguageOption("Portuguese (Brazil)", new CultureInfo("pt-BR")),
+            new LanguageOption("Portuguese (Portugal)", new CultureInfo("pt-PT")),
+            new LanguageOption("Chinese (Mandarin)", new CultureInfo("zh-CN")),
+            new LanguageOption("Japanese", new CultureInfo("ja-JP")),
+            new LanguageOption("Hindi", new CultureInfo("hi-IN"))
+        };
+
+        private WaspiLoopbackAudioSource? loopbackAudioSource;
+        private Task? transcriptionTask;
+        private CancellationTokenSource transcriptionCancellation = new();
+        private SileroVadDetectorFactory? vadDetectorFactory;
+        private WhisperFactory? whisperFactory;
+        private WhisperSpeechTranscriptorFactory? whisperTranscriptorFactory;
+        private EchoSharpRealtimeTranscriptorFactory? realtimeFactory;
+        private IRealtimeSpeechTranscriptor? realtimeTranscriptor;
+        private string? currentModelPath;
 
         public Form1()
         {
             InitializeComponent();
-            LoadTask = LoadModels();
+            ConfigureOptionControls();
         }
 
-        public async Task LoadModels()
+        private void ConfigureOptionControls()
         {
-            if (!Directory.Exists("models"))
+            modelComboBox.DisplayMember = nameof(ModelOption.DisplayName);
+            modelComboBox.ValueMember = nameof(ModelOption.ModelType);
+            modelComboBox.DataSource = modelOptions;
+            modelComboBox.SelectedItem = modelOptions.First(option => option.ModelType == GgmlType.Medium);
+
+            languageComboBox.DisplayMember = nameof(LanguageOption.DisplayName);
+            languageComboBox.ValueMember = nameof(LanguageOption.Culture);
+            languageComboBox.DataSource = languageOptions;
+            languageComboBox.SelectedItem = languageOptions.First();
+
+            UpdateLanguageControls();
+            UpdateSamplingControls();
+        }
+
+        private void UpdateLanguageControls()
+        {
+            languageComboBox.Enabled = !autoDetectLanguageCheckBox.Checked;
+        }
+
+        private void UpdateSamplingControls()
+        {
+            bestOfNumericUpDown.Enabled = greedyRadioButton.Checked;
+            beamSizeNumericUpDown.Enabled = beamSearchRadioButton.Checked;
+            patienceNumericUpDown.Enabled = beamSearchRadioButton.Checked;
+        }
+
+        private async Task EnsureVadDetectorAsync()
+        {
+            Directory.CreateDirectory(ModelsDirectory);
+            if (vadDetectorFactory != null)
             {
-                Directory.CreateDirectory("models");
+                return;
             }
-            var sileroOnnxPath = "models/silero_vad.onnx";
-            if (!File.Exists(sileroOnnxPath))
+
+            var vadPath = Path.Combine(ModelsDirectory, "silero_vad.onnx");
+            if (!File.Exists(vadPath))
             {
-                using (var client = new WebClient())
+                using var client = new WebClient();
+                await client.DownloadFileTaskAsync(SileroVadUri, vadPath);
+            }
+
+            vadDetectorFactory = new SileroVadDetectorFactory(new SileroVadOptions(vadPath)
+            {
+                Threshold = 0.5f,
+                ThresholdGap = 0.15f
+            });
+        }
+
+        private static async Task EnsureModelFileAsync(GgmlType modelType, string destinationPath)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            if (File.Exists(destinationPath))
+            {
+                return;
+            }
+
+            using var modelStream = await WhisperGgmlDownloader.Default.GetGgmlModelAsync(modelType);
+            using var fileWriter = File.Open(destinationPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+            await modelStream.CopyToAsync(fileWriter);
+        }
+
+        private async Task EnsureRealtimeTranscriptorAsync()
+        {
+            await EnsureVadDetectorAsync();
+
+            var selectedModel = (ModelOption)(modelComboBox.SelectedItem ?? modelOptions[0]);
+            var modelPath = Path.Combine(ModelsDirectory, selectedModel.FileName);
+            await EnsureModelFileAsync(selectedModel.ModelType, modelPath);
+
+            if (!string.Equals(currentModelPath, modelPath, StringComparison.OrdinalIgnoreCase))
+            {
+                whisperFactory?.Dispose();
+                whisperFactory = WhisperFactory.FromPath(modelPath);
+                currentModelPath = modelPath;
+            }
+
+            var builder = whisperFactory!.CreateBuilder()
+                .WithThreads(Math.Max(1, Environment.ProcessorCount))
+                .WithTemperature((float)temperatureNumericUpDown.Value)
+                .WithNoSpeechThreshold((float)noSpeechNumericUpDown.Value)
+                .WithLogProbThreshold((float)logProbNumericUpDown.Value);
+
+            if (translateCheckBox.Checked)
+            {
+                builder.WithTranslate();
+            }
+
+            if (autoDetectLanguageCheckBox.Checked)
+            {
+                builder.WithLanguageDetection();
+            }
+            else if (languageComboBox.SelectedItem is LanguageOption { Culture: { } culture })
+            {
+                builder.WithLanguage(culture.TwoLetterISOLanguageName);
+            }
+
+            if (beamSearchRadioButton.Checked)
+            {
+                builder.WithBeamSearchSamplingStrategy()
+                       .WithBeamSize((int)beamSizeNumericUpDown.Value)
+                       .WithPatience((float)patienceNumericUpDown.Value);
+            }
+            else
+            {
+                builder.WithGreedySamplingStrategy()
+                       .WithBestOf((int)bestOfNumericUpDown.Value);
+            }
+
+            whisperTranscriptorFactory?.Dispose();
+            whisperTranscriptorFactory = new WhisperSpeechTranscriptorFactory(builder);
+
+            realtimeFactory = new EchoSharpRealtimeTranscriptorFactory(
+                whisperTranscriptorFactory,
+                vadDetectorFactory!,
+                new EchoSharpRealtimeOptions
                 {
-                    client.DownloadFile(new Uri("https://github.com/sandrohanea/silero-vad/raw/refs/tags/v1/src/silero_vad/data/silero_vad.onnx"), sileroOnnxPath);
+                    ConcatenateSegmentsToPrompt = false
+                });
+
+            var language = (languageComboBox.SelectedItem as LanguageOption)?.Culture ?? new CultureInfo("en-US");
+
+            realtimeTranscriptor = realtimeFactory.Create(new RealtimeSpeechTranscriptorOptions
+            {
+                AutodetectLanguageOnce = autoDetectLanguageCheckBox.Checked,
+                IncludeSpeechRecogizingEvents = true,
+                RetrieveTokenDetails = true,
+                LanguageAutoDetect = autoDetectLanguageCheckBox.Checked,
+                Language = language
+            });
+        }
+
+        private async void startButton_Click(object? sender, EventArgs e)
+        {
+            if (loopbackAudioSource != null)
+            {
+                return;
+            }
+
+            startButton.Enabled = false;
+            stopButton.Enabled = false;
+            statusLabel.Text = "Status: Preparing...";
+            transcriptTextBox.Clear();
+
+            try
+            {
+                await EnsureRealtimeTranscriptorAsync();
+
+                loopbackAudioSource = new WaspiLoopbackAudioSource();
+                loopbackAudioSource.StartRecording();
+
+                transcriptionCancellation = new CancellationTokenSource();
+                stopButton.Enabled = true;
+                statusLabel.Text = "Status: Listening...";
+
+                transcriptionTask = ShowTranscriptAsync(transcriptionCancellation.Token);
+            }
+            catch (Exception ex)
+            {
+                statusLabel.Text = "Status: Error";
+                MessageBox.Show(this, $"Unable to start transcription: {ex.Message}", "Transcription error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                loopbackAudioSource?.Dispose();
+                loopbackAudioSource = null;
+                startButton.Enabled = true;
+                stopButton.Enabled = false;
+            }
+        }
+
+        private async void stopButton_Click(object? sender, EventArgs e)
+        {
+            stopButton.Enabled = false;
+
+            if (loopbackAudioSource == null)
+            {
+                startButton.Enabled = true;
+                return;
+            }
+
+            try
+            {
+                loopbackAudioSource.StopRecording();
+            }
+            catch
+            {
+            }
+            finally
+            {
+                loopbackAudioSource.Dispose();
+                loopbackAudioSource = null;
+            }
+
+            transcriptionCancellation.Cancel();
+
+            if (transcriptionTask != null)
+            {
+                try
+                {
+                    await transcriptionTask;
+                }
+                catch (OperationCanceledException)
+                {
                 }
             }
-            vadDetectorFactory = new SileroVadDetectorFactory(new SileroVadOptions(sileroOnnxPath)
-            {
-                Threshold = 0f, // The threshold for Silero VAD. The default is 0.5f.
-                ThresholdGap = 0f, // The threshold gap for Silero VAD. The default is 0.15f.
-            });
-            var ggmlModelPath = "models/ggml-Medium.bin";
-            if (!File.Exists(ggmlModelPath))
-            {
-                using var modelStream = await WhisperGgmlDownloader.Default.GetGgmlModelAsync(GgmlType.Medium);
-                using var fileWriter = File.OpenWrite(ggmlModelPath);
-                await modelStream.CopyToAsync(fileWriter);
-            }
-            factory = WhisperFactory.FromPath(ggmlModelPath);
-            speechTranscriptorFactory = new WhisperSpeechTranscriptorFactory(factory.CreateBuilder().WithTranslate().WithLanguageDetection());
 
-            realTimeFactory = new EchoSharpRealtimeTranscriptorFactory(speechTranscriptorFactory, vadDetectorFactory, echoSharpOptions: new EchoSharpRealtimeOptions()
-            {
-                ConcatenateSegmentsToPrompt = false // Flag to concatenate segments to prompt when new segment is recognized (for the whole session)
-            });
+            transcriptionCancellation.Dispose();
+            transcriptionCancellation = new CancellationTokenSource();
+            transcriptionTask = null;
 
-            realTimeTranscriptor = realTimeFactory.Create(new RealtimeSpeechTranscriptorOptions()
-            {
-                AutodetectLanguageOnce = false, // Flag to detect the language only once or for each segment
-                IncludeSpeechRecogizingEvents = true, // Flag to include speech recognizing events (RealtimeSegmentRecognizing)
-                RetrieveTokenDetails = true, // Flag to retrieve token details
-                LanguageAutoDetect = false, // Flag to auto-detect the language
-                Language = new CultureInfo("en-US"), // Language to use for transcription
-            });
+            statusLabel.Text = "Status: Stopped";
+            startButton.Enabled = true;
         }
 
-        private async void button1_Click(object sender, EventArgs e)
+        private async Task ShowTranscriptAsync(CancellationToken cancellationToken)
         {
-            await LoadTask;
-            if (waveloop == null)
+            if (realtimeTranscriptor == null || loopbackAudioSource == null)
             {
+                return;
+            }
 
-
-                waveloop = new WaspiLoopbackAudioSource();
-                //waveloop = new MicrophoneInputSource();
-
-                async Task ShowTranscriptAsync()
+            try
+            {
+                await foreach (var transcription in realtimeTranscriptor.TranscribeAsync(loopbackAudioSource, cancellationToken))
                 {
-                    await foreach (var transcription in realTimeTranscriptor.TranscribeAsync(waveloop, token.Token))
+                    switch (transcription)
                     {
-                        var eventType = transcription.GetType().Name;
-                        this.Invoke(new Action(() => label1.Text = eventType));
-
-                        var textToWrite = transcription switch
-                        {
-                            RealtimeSegmentRecognized segmentRecognized => $"{segmentRecognized.Segment.StartTime}-{segmentRecognized.Segment.StartTime + segmentRecognized.Segment.Duration}:{segmentRecognized.Segment.Text}",
-                            RealtimeSegmentRecognizing segmentRecognizing => $"{segmentRecognizing.Segment.StartTime}-{segmentRecognizing.Segment.StartTime + segmentRecognizing.Segment.Duration}:{segmentRecognizing.Segment.Text}",
-                            RealtimeSessionStarted sessionStarted => $"SessionId: {sessionStarted.SessionId}",
-                            RealtimeSessionStopped sessionStopped => $"SessionId: {sessionStopped.SessionId}",
-                            _ => string.Empty
-                        };
-                        this.Invoke(new Action(() => label2.Text = textToWrite));
+                        case RealtimeSegmentRecognized recognized:
+                            AppendRecognizedSegment(recognized);
+                            break;
+                        case RealtimeSegmentRecognizing recognizing:
+                            UpdateRecognizingStatus(recognizing);
+                            break;
+                        case RealtimeSessionStarted started:
+                            UpdateStatus($"Status: Session {started.SessionId} started");
+                            break;
+                        case RealtimeSessionStopped:
+                            UpdateStatus("Status: Listening...");
+                            break;
                     }
-                    this.Invoke(new Action(() => label2.Text = "Completed"));
                 }
-                ;
-                waveloop.StartRecording();
-                showTranscriptTask = ShowTranscriptAsync();
-
+            }
+            catch (OperationCanceledException)
+            {
+                UpdateStatus("Status: Stopped");
+            }
+            catch (Exception ex)
+            {
+                UpdateStatus("Status: Error");
+                BeginInvoke(new Action(() =>
+                {
+                    MessageBox.Show(this, $"Transcription failed: {ex.Message}", "Transcription error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }));
+            }
+            finally
+            {
+                BeginInvoke(new Action(() => stopButton.Enabled = false));
+                BeginInvoke(new Action(() => startButton.Enabled = true));
             }
         }
 
-        private void button2_Click(object sender, EventArgs e)
+        private void AppendRecognizedSegment(RealtimeSegmentRecognized recognized)
         {
-            if (waveloop != null)
+            var text = recognized.Segment.Text?.Trim();
+            if (string.IsNullOrEmpty(text))
             {
-                MessageBox.Show(waveloop.Duration.ToString());
-                waveloop.StopRecording();
-                waveloop.Dispose();
-                waveloop = null;
-                token.Cancel();
+                return;
             }
+
+            BeginInvoke(new Action(() =>
+            {
+                transcriptTextBox.AppendText(text + Environment.NewLine);
+                statusLabel.Text = "Status: Listening...";
+            }));
+        }
+
+        private void UpdateRecognizingStatus(RealtimeSegmentRecognizing recognizing)
+        {
+            var text = recognizing.Segment.Text;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            UpdateStatus($"Status: Hearing... {text.Trim()}");
+        }
+
+        private void UpdateStatus(string status)
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            BeginInvoke(new Action(() => statusLabel.Text = status));
+        }
+
+        private void autoDetectLanguageCheckBox_CheckedChanged(object? sender, EventArgs e)
+        {
+            UpdateLanguageControls();
+        }
+
+        private void samplingRadioButton_CheckedChanged(object? sender, EventArgs e)
+        {
+            UpdateSamplingControls();
         }
 
         protected override void OnFormClosed(FormClosedEventArgs e)
         {
             base.OnFormClosed(e);
-            if (waveloop != null)
-            {
-                waveloop.StopRecording();
-                waveloop.Dispose();
-
-                factory.Dispose();
-                speechTranscriptorFactory.Dispose();
-    }
+            CleanupResources();
         }
 
+        private void CleanupResources()
+        {
+            try
+            {
+                transcriptionCancellation.Cancel();
+            }
+            catch
+            {
+            }
+
+            transcriptionTask = null;
+            transcriptionCancellation.Dispose();
+
+            loopbackAudioSource?.Dispose();
+            loopbackAudioSource = null;
+
+            if (realtimeTranscriptor is IDisposable disposableTranscriptor)
+            {
+                disposableTranscriptor.Dispose();
+            }
+
+            (realtimeFactory as IDisposable)?.Dispose();
+            whisperTranscriptorFactory?.Dispose();
+            whisperFactory?.Dispose();
+            (vadDetectorFactory as IDisposable)?.Dispose();
+        }
+
+        private sealed record ModelOption(string DisplayName, GgmlType ModelType, string FileName);
+
+        private sealed record LanguageOption(string DisplayName, CultureInfo? Culture);
     }
 }

--- a/liveTranscribe/WaspiLoopbackAudioSource.cs
+++ b/liveTranscribe/WaspiLoopbackAudioSource.cs
@@ -1,108 +1,115 @@
-﻿using EchoSharp.Audio;
+using EchoSharp.Audio;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Buffers;
+using System.IO;
 
 namespace liveTranscribe
 {
-    internal class WaspiLoopbackAudioSource : AwaitableWaveFileSource
+    internal sealed class WaspiLoopbackAudioSource : AwaitableWaveFileSource
     {
-        WasapiLoopbackCapture waveloop;
-        WaveFormat format;
-        WaveFormat inFormat;
-        private WaveFileWriter? waveFile;
+        private readonly WasapiLoopbackCapture loopbackCapture;
+        private readonly WaveFormat inputFormat;
 
-        public byte[] ToPCM16(byte[] buffer, int length, WaveFormat format)
+        public WaspiLoopbackAudioSource()
         {
-            if (length == 0)
-            {
-                return new byte[0];
-            }
+            loopbackCapture = new WasapiLoopbackCapture();
+            inputFormat = loopbackCapture.WaveFormat;
 
-            using var memStream = new MemoryStream(buffer, 0, length);
-            using var inputStream = new RawSourceWaveStream(memStream, format);
-
-            var convertedPCM = new SampleToWaveProvider16(
-                    new WdlResamplingSampleProvider(
-                        new WaveToSampleProvider(inputStream), 16000)
-                );
-
-            byte[] convertedBuffer = new byte[length];
-
-            using var stream = new MemoryStream();
-            int read;
-
-            while ((read = convertedPCM.Read(convertedBuffer, 0, length)) > 0)
-                stream.Write(convertedBuffer, 0, read);
-
-            return stream.ToArray();
-        }
-
-        public WaspiLoopbackAudioSource() : base(aggregationStrategy: DefaultChannelAggregationStrategies.SelectChannel(0))
-        {
-            
-            waveloop = new WasapiLoopbackCapture();
-
-            Initialize(new AudioSourceHeader()
+            Initialize(new AudioSourceHeader
             {
                 BitsPerSample = 16,
                 Channels = 1,
                 SampleRate = 16000
             });
-            
-            
-            //format = new WaveFormat(16000, 2);
-            inFormat = WaveFormat.CreateIeeeFloatWaveFormat(48000, 2);
-            
-            waveloop.DataAvailable += Waveloop_DataAvailable;
-            waveloop.RecordingStopped += Waveloop_RecordingStopped;
+
+            loopbackCapture.DataAvailable += OnDataAvailable;
+            loopbackCapture.RecordingStopped += OnRecordingStopped;
         }
 
         public void StartRecording()
         {
-            waveloop.StartRecording();
-            //waveFile = new WaveFileWriter("testStream.wav", format);
+            loopbackCapture.StartRecording();
         }
 
         public void StopRecording()
         {
-            waveloop.StopRecording();
-            //waveFile?.Flush();
-            //waveFile?.Close();
+            loopbackCapture.StopRecording();
+        }
+
+        private byte[] ConvertToPcm16(byte[] buffer, int bytesRecorded)
+        {
+            if (bytesRecorded <= 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            using var memoryStream = new MemoryStream(buffer, 0, bytesRecorded, writable: false);
+            using var rawStream = new RawSourceWaveStream(memoryStream, inputFormat);
+
+            ISampleProvider sampleProvider = new WaveToSampleProvider(rawStream);
+            if (sampleProvider.WaveFormat.Channels > 1)
+            {
+                sampleProvider = new StereoToMonoSampleProvider(sampleProvider)
+                {
+                    LeftVolume = 0.5f,
+                    RightVolume = 0.5f
+                };
+            }
+
+            var resampled = new WdlResamplingSampleProvider(sampleProvider, 16000);
+            var pcmProvider = new SampleToWaveProvider16(resampled);
+
+            using var outputStream = new MemoryStream();
+            var rentedBuffer = ArrayPool<byte>.Shared.Rent(4096);
+            try
+            {
+                int read;
+                while ((read = pcmProvider.Read(rentedBuffer, 0, rentedBuffer.Length)) > 0)
+                {
+                    outputStream.Write(rentedBuffer, 0, read);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rentedBuffer);
+            }
+
+            return outputStream.ToArray();
+        }
+
+        private void OnDataAvailable(object? sender, WaveInEventArgs e)
+        {
+            var converted = ConvertToPcm16(e.Buffer, e.BytesRecorded);
+            if (converted.Length == 0)
+            {
+                return;
+            }
+
+            WriteData(converted.AsMemory());
+        }
+
+        private void OnRecordingStopped(object? sender, StoppedEventArgs e)
+        {
+            if (e.Exception != null)
+            {
+                throw e.Exception;
+            }
+
+            Flush();
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                waveloop.DataAvailable -= Waveloop_DataAvailable;
-                waveloop.RecordingStopped -= Waveloop_RecordingStopped;
-                waveloop.Dispose();
+                loopbackCapture.DataAvailable -= OnDataAvailable;
+                loopbackCapture.RecordingStopped -= OnRecordingStopped;
+                loopbackCapture.Dispose();
             }
+
             base.Dispose(disposing);
-        }
-
-        private void Waveloop_DataAvailable(object? sender, WaveInEventArgs e)
-        {
-
-
-
-            var buffer = ToPCM16(e.Buffer, e.BytesRecorded, inFormat);
-            //waveFile?.Write(buffer, 0, buffer.Length);
-            WriteData(buffer.AsMemory(0, buffer.Length));
-        }
-
-        private void Waveloop_RecordingStopped(object? sender, StoppedEventArgs e)
-        {
-            if (e.Exception != null)
-            {
-                throw e.Exception;
-            }
-            Flush();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a richer UI with selectable Whisper models, language handling, sampling strategy, and decoding thresholds so transcription quality can be tuned at runtime
- rebuild the transcription pipeline to load the chosen model/VAD assets, apply the requested Whisper builder options, and manage realtime sessions with better status updates
- resample loopback audio to clean 16kHz mono PCM and restore sensible Silero VAD thresholds for improved recognition accuracy

## Testing
- not run (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfa6c11c7c83279fcac137e9d0b762