### PR TITLE
Improve audio pipeline and expose Whisper tuning options

### DIFF
--- a/liveTranscribe/Form1.Designer.cs
+++ b/liveTranscribe/Form1.Designer.cs
@@ -1,11 +1,15 @@
-﻿namespace liveTranscribe
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace liveTranscribe
 {
     partial class Form1
     {
         /// <summary>
         ///  Required designer variable.
         /// </summary>
-        private System.ComponentModel.IContainer components = null;
+        private System.ComponentModel.IContainer? components = null;
 
         /// <summary>
         ///  Clean up any resources being used.
@@ -29,77 +33,371 @@
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            notifyIcon1 = new NotifyIcon(components);
-            button1 = new Button();
-            button2 = new Button();
-            label1 = new Label();
-            label2 = new Label();
+            startButton = new Button();
+            stopButton = new Button();
+            statusLabel = new Label();
+            transcriptTextBox = new TextBox();
+            modelLabel = new Label();
+            modelComboBox = new ComboBox();
+            temperatureLabel = new Label();
+            temperatureNumeric = new NumericUpDown();
+            beamLabel = new Label();
+            beamSizeNumeric = new NumericUpDown();
+            bestOfLabel = new Label();
+            bestOfNumeric = new NumericUpDown();
+            translateCheckBox = new CheckBox();
+            autoDetectLanguageCheckBox = new CheckBox();
+            languageLabel = new Label();
+            languageTextBox = new TextBox();
+            autodetectOnceCheckBox = new CheckBox();
+            partialResultsCheckBox = new CheckBox();
+            tokenDetailsCheckBox = new CheckBox();
+            vadThresholdLabel = new Label();
+            vadThresholdNumeric = new NumericUpDown();
+            vadGapLabel = new Label();
+            vadGapNumeric = new NumericUpDown();
+            threadsLabel = new Label();
+            threadsNumeric = new NumericUpDown();
+            promptLabel = new Label();
+            promptTextBox = new TextBox();
+            ((System.ComponentModel.ISupportInitialize)temperatureNumeric).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)beamSizeNumeric).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)bestOfNumeric).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)vadThresholdNumeric).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)vadGapNumeric).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)threadsNumeric).BeginInit();
             SuspendLayout();
             // 
-            // notifyIcon1
+            // startButton
             // 
-            notifyIcon1.Text = "notifyIcon1";
-            notifyIcon1.Visible = true;
+            startButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            startButton.Location = new Point(654, 122);
+            startButton.Name = "startButton";
+            startButton.Size = new Size(66, 27);
+            startButton.TabIndex = 0;
+            startButton.Text = "Start";
+            startButton.UseVisualStyleBackColor = true;
+            startButton.Click += button1_Click;
             // 
-            // button1
+            // stopButton
             // 
-            button1.Location = new Point(309, 156);
-            button1.Name = "button1";
-            button1.Size = new Size(75, 23);
-            button1.TabIndex = 0;
-            button1.Text = "button1";
-            button1.UseVisualStyleBackColor = true;
-            button1.Click += button1_Click;
+            stopButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            stopButton.Enabled = false;
+            stopButton.Location = new Point(726, 122);
+            stopButton.Name = "stopButton";
+            stopButton.Size = new Size(62, 27);
+            stopButton.TabIndex = 1;
+            stopButton.Text = "Stop";
+            stopButton.UseVisualStyleBackColor = true;
+            stopButton.Click += button2_Click;
             // 
-            // button2
+            // statusLabel
             // 
-            button2.Location = new Point(420, 234);
-            button2.Name = "button2";
-            button2.Size = new Size(75, 23);
-            button2.TabIndex = 1;
-            button2.Text = "button2";
-            button2.UseVisualStyleBackColor = true;
-            button2.Click += button2_Click;
+            statusLabel.AutoSize = true;
+            statusLabel.Location = new Point(12, 9);
+            statusLabel.Name = "statusLabel";
+            statusLabel.Size = new Size(66, 15);
+            statusLabel.TabIndex = 2;
+            statusLabel.Text = "Status: Idle";
             // 
-            // label1
+            // transcriptTextBox
             // 
-            label1.AutoSize = true;
-            label1.Location = new Point(167, 33);
-            label1.Name = "label1";
-            label1.Size = new Size(38, 15);
-            label1.TabIndex = 2;
-            label1.Text = "label1";
+            transcriptTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            transcriptTextBox.Location = new Point(12, 168);
+            transcriptTextBox.Multiline = true;
+            transcriptTextBox.Name = "transcriptTextBox";
+            transcriptTextBox.ReadOnly = true;
+            transcriptTextBox.ScrollBars = ScrollBars.Vertical;
+            transcriptTextBox.Size = new Size(776, 270);
+            transcriptTextBox.TabIndex = 3;
             // 
-            // label2
+            // modelLabel
             // 
-            label2.AutoSize = true;
-            label2.Location = new Point(167, 65);
-            label2.Name = "label2";
-            label2.Size = new Size(38, 15);
-            label2.TabIndex = 3;
-            label2.Text = "label2";
+            modelLabel.AutoSize = true;
+            modelLabel.Location = new Point(12, 38);
+            modelLabel.Name = "modelLabel";
+            modelLabel.Size = new Size(42, 15);
+            modelLabel.TabIndex = 4;
+            modelLabel.Text = "Model";
+            // 
+            // modelComboBox
+            // 
+            modelComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            modelComboBox.FormattingEnabled = true;
+            modelComboBox.Location = new Point(120, 34);
+            modelComboBox.Name = "modelComboBox";
+            modelComboBox.Size = new Size(150, 23);
+            modelComboBox.TabIndex = 5;
+            // 
+            // temperatureLabel
+            // 
+            temperatureLabel.AutoSize = true;
+            temperatureLabel.Location = new Point(290, 38);
+            temperatureLabel.Name = "temperatureLabel";
+            temperatureLabel.Size = new Size(77, 15);
+            temperatureLabel.TabIndex = 6;
+            temperatureLabel.Text = "Temperature";
+            // 
+            // temperatureNumeric
+            // 
+            temperatureNumeric.DecimalPlaces = 2;
+            temperatureNumeric.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
+            temperatureNumeric.Location = new Point(373, 34);
+            temperatureNumeric.Maximum = new decimal(new int[] { 1, 0, 0, 0 });
+            temperatureNumeric.Name = "temperatureNumeric";
+            temperatureNumeric.Size = new Size(70, 23);
+            temperatureNumeric.TabIndex = 7;
+            // 
+            // beamLabel
+            // 
+            beamLabel.AutoSize = true;
+            beamLabel.Location = new Point(452, 38);
+            beamLabel.Name = "beamLabel";
+            beamLabel.Size = new Size(63, 15);
+            beamLabel.TabIndex = 8;
+            beamLabel.Text = "Beam size";
+            // 
+            // beamSizeNumeric
+            // 
+            beamSizeNumeric.Location = new Point(521, 34);
+            beamSizeNumeric.Maximum = new decimal(new int[] { 16, 0, 0, 0 });
+            beamSizeNumeric.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            beamSizeNumeric.Name = "beamSizeNumeric";
+            beamSizeNumeric.Size = new Size(60, 23);
+            beamSizeNumeric.TabIndex = 9;
+            beamSizeNumeric.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            // 
+            // bestOfLabel
+            // 
+            bestOfLabel.AutoSize = true;
+            bestOfLabel.Location = new Point(598, 38);
+            bestOfLabel.Name = "bestOfLabel";
+            bestOfLabel.Size = new Size(44, 15);
+            bestOfLabel.TabIndex = 10;
+            bestOfLabel.Text = "Best of";
+            // 
+            // bestOfNumeric
+            // 
+            bestOfNumeric.Location = new Point(648, 34);
+            bestOfNumeric.Maximum = new decimal(new int[] { 10, 0, 0, 0 });
+            bestOfNumeric.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            bestOfNumeric.Name = "bestOfNumeric";
+            bestOfNumeric.Size = new Size(60, 23);
+            bestOfNumeric.TabIndex = 11;
+            bestOfNumeric.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            // 
+            // translateCheckBox
+            // 
+            translateCheckBox.AutoSize = true;
+            translateCheckBox.Location = new Point(12, 128);
+            translateCheckBox.Name = "translateCheckBox";
+            translateCheckBox.Size = new Size(137, 19);
+            translateCheckBox.TabIndex = 12;
+            translateCheckBox.Text = "Translate to English";
+            translateCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // autoDetectLanguageCheckBox
+            // 
+            autoDetectLanguageCheckBox.AutoSize = true;
+            autoDetectLanguageCheckBox.Location = new Point(522, 67);
+            autoDetectLanguageCheckBox.Name = "autoDetectLanguageCheckBox";
+            autoDetectLanguageCheckBox.Size = new Size(142, 19);
+            autoDetectLanguageCheckBox.TabIndex = 13;
+            autoDetectLanguageCheckBox.Text = "Auto detect language";
+            autoDetectLanguageCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // languageLabel
+            // 
+            languageLabel.AutoSize = true;
+            languageLabel.Location = new Point(200, 67);
+            languageLabel.Name = "languageLabel";
+            languageLabel.Size = new Size(61, 15);
+            languageLabel.TabIndex = 14;
+            languageLabel.Text = "Language";
+            // 
+            // languageTextBox
+            // 
+            languageTextBox.Location = new Point(267, 63);
+            languageTextBox.Name = "languageTextBox";
+            languageTextBox.Size = new Size(90, 23);
+            languageTextBox.TabIndex = 15;
+            // 
+            // autodetectOnceCheckBox
+            // 
+            autodetectOnceCheckBox.AutoSize = true;
+            autodetectOnceCheckBox.Location = new Point(522, 92);
+            autodetectOnceCheckBox.Name = "autodetectOnceCheckBox";
+            autodetectOnceCheckBox.Size = new Size(90, 19);
+            autodetectOnceCheckBox.TabIndex = 16;
+            autodetectOnceCheckBox.Text = "Detect once";
+            autodetectOnceCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // partialResultsCheckBox
+            // 
+            partialResultsCheckBox.AutoSize = true;
+            partialResultsCheckBox.Location = new Point(12, 99);
+            partialResultsCheckBox.Name = "partialResultsCheckBox";
+            partialResultsCheckBox.Size = new Size(134, 19);
+            partialResultsCheckBox.TabIndex = 17;
+            partialResultsCheckBox.Text = "Show partial results";
+            partialResultsCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // tokenDetailsCheckBox
+            // 
+            tokenDetailsCheckBox.AutoSize = true;
+            tokenDetailsCheckBox.Location = new Point(172, 99);
+            tokenDetailsCheckBox.Name = "tokenDetailsCheckBox";
+            tokenDetailsCheckBox.Size = new Size(139, 19);
+            tokenDetailsCheckBox.TabIndex = 18;
+            tokenDetailsCheckBox.Text = "Include token details";
+            tokenDetailsCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // vadThresholdLabel
+            // 
+            vadThresholdLabel.AutoSize = true;
+            vadThresholdLabel.Location = new Point(320, 99);
+            vadThresholdLabel.Name = "vadThresholdLabel";
+            vadThresholdLabel.Size = new Size(85, 15);
+            vadThresholdLabel.TabIndex = 19;
+            vadThresholdLabel.Text = "VAD threshold";
+            // 
+            // vadThresholdNumeric
+            // 
+            vadThresholdNumeric.DecimalPlaces = 2;
+            vadThresholdNumeric.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
+            vadThresholdNumeric.Location = new Point(411, 95);
+            vadThresholdNumeric.Maximum = new decimal(new int[] { 1, 0, 0, 0 });
+            vadThresholdNumeric.Name = "vadThresholdNumeric";
+            vadThresholdNumeric.Size = new Size(60, 23);
+            vadThresholdNumeric.TabIndex = 20;
+            // 
+            // vadGapLabel
+            // 
+            vadGapLabel.AutoSize = true;
+            vadGapLabel.Location = new Point(477, 99);
+            vadGapLabel.Name = "vadGapLabel";
+            vadGapLabel.Size = new Size(53, 15);
+            vadGapLabel.TabIndex = 21;
+            vadGapLabel.Text = "VAD gap";
+            // 
+            // vadGapNumeric
+            // 
+            vadGapNumeric.DecimalPlaces = 2;
+            vadGapNumeric.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
+            vadGapNumeric.Location = new Point(536, 95);
+            vadGapNumeric.Maximum = new decimal(new int[] { 1, 0, 0, 0 });
+            vadGapNumeric.Name = "vadGapNumeric";
+            vadGapNumeric.Size = new Size(60, 23);
+            vadGapNumeric.TabIndex = 22;
+            // 
+            // threadsLabel
+            // 
+            threadsLabel.AutoSize = true;
+            threadsLabel.Location = new Point(12, 67);
+            threadsLabel.Name = "threadsLabel";
+            threadsLabel.Size = new Size(48, 15);
+            threadsLabel.TabIndex = 23;
+            threadsLabel.Text = "Threads";
+            // 
+            // threadsNumeric
+            // 
+            threadsNumeric.Location = new Point(120, 63);
+            threadsNumeric.Maximum = new decimal(new int[] { 256, 0, 0, 0 });
+            threadsNumeric.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            threadsNumeric.Name = "threadsNumeric";
+            threadsNumeric.Size = new Size(60, 23);
+            threadsNumeric.TabIndex = 24;
+            threadsNumeric.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            // 
+            // promptLabel
+            // 
+            promptLabel.AutoSize = true;
+            promptLabel.Location = new Point(172, 132);
+            promptLabel.Name = "promptLabel";
+            promptLabel.Size = new Size(77, 15);
+            promptLabel.TabIndex = 25;
+            promptLabel.Text = "Initial prompt";
+            // 
+            // promptTextBox
+            // 
+            promptTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            promptTextBox.Location = new Point(255, 128);
+            promptTextBox.Name = "promptTextBox";
+            promptTextBox.Size = new Size(393, 23);
+            promptTextBox.TabIndex = 26;
             // 
             // Form1
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(800, 450);
-            Controls.Add(label2);
-            Controls.Add(label1);
-            Controls.Add(button2);
-            Controls.Add(button1);
+            Controls.Add(promptTextBox);
+            Controls.Add(promptLabel);
+            Controls.Add(threadsNumeric);
+            Controls.Add(threadsLabel);
+            Controls.Add(vadGapNumeric);
+            Controls.Add(vadGapLabel);
+            Controls.Add(vadThresholdNumeric);
+            Controls.Add(vadThresholdLabel);
+            Controls.Add(tokenDetailsCheckBox);
+            Controls.Add(partialResultsCheckBox);
+            Controls.Add(autodetectOnceCheckBox);
+            Controls.Add(languageTextBox);
+            Controls.Add(languageLabel);
+            Controls.Add(autoDetectLanguageCheckBox);
+            Controls.Add(translateCheckBox);
+            Controls.Add(bestOfNumeric);
+            Controls.Add(bestOfLabel);
+            Controls.Add(beamSizeNumeric);
+            Controls.Add(beamLabel);
+            Controls.Add(temperatureNumeric);
+            Controls.Add(temperatureLabel);
+            Controls.Add(modelComboBox);
+            Controls.Add(modelLabel);
+            Controls.Add(transcriptTextBox);
+            Controls.Add(statusLabel);
+            Controls.Add(stopButton);
+            Controls.Add(startButton);
             Name = "Form1";
-            Text = "Form1";
+            Text = "Live Transcribe";
+            ((System.ComponentModel.ISupportInitialize)temperatureNumeric).EndInit();
+            ((System.ComponentModel.ISupportInitialize)beamSizeNumeric).EndInit();
+            ((System.ComponentModel.ISupportInitialize)bestOfNumeric).EndInit();
+            ((System.ComponentModel.ISupportInitialize)vadThresholdNumeric).EndInit();
+            ((System.ComponentModel.ISupportInitialize)vadGapNumeric).EndInit();
+            ((System.ComponentModel.ISupportInitialize)threadsNumeric).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
 
         #endregion
 
-        private NotifyIcon notifyIcon1;
-        private Button button1;
-        private Button button2;
-        private Label label1;
-        private Label label2;
+        private Button startButton;
+        private Button stopButton;
+        private Label statusLabel;
+        private TextBox transcriptTextBox;
+        private Label modelLabel;
+        private ComboBox modelComboBox;
+        private Label temperatureLabel;
+        private NumericUpDown temperatureNumeric;
+        private Label beamLabel;
+        private NumericUpDown beamSizeNumeric;
+        private Label bestOfLabel;
+        private NumericUpDown bestOfNumeric;
+        private CheckBox translateCheckBox;
+        private CheckBox autoDetectLanguageCheckBox;
+        private Label languageLabel;
+        private TextBox languageTextBox;
+        private CheckBox autodetectOnceCheckBox;
+        private CheckBox partialResultsCheckBox;
+        private CheckBox tokenDetailsCheckBox;
+        private Label vadThresholdLabel;
+        private NumericUpDown vadThresholdNumeric;
+        private Label vadGapLabel;
+        private NumericUpDown vadGapNumeric;
+        private Label threadsLabel;
+        private NumericUpDown threadsNumeric;
+        private Label promptLabel;
+        private TextBox promptTextBox;
     }
 }

--- a/liveTranscribe/Form1.cs
+++ b/liveTranscribe/Form1.cs
@@ -1,40 +1,82 @@
-using EchoSharp.Abstractions.Audio;
 using EchoSharp.Abstractions.SpeechTranscription;
-using EchoSharp.NAudio;
 using EchoSharp.Onnx.SileroVad;
 using EchoSharp.SpeechTranscription;
 using EchoSharp.Whisper.net;
-using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
-using NAudio.Wave;
-using NAudio.Wave.SampleProviders;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Whisper.net;
 using Whisper.net.Ggml;
-using Whisper.net.LibraryLoader;
 namespace liveTranscribe
 {
     public partial class Form1 : Form
     {
-        WaspiLoopbackAudioSource waveloop;
-        Task showTranscriptTask;
-        Task LoadTask;
-        private IRealtimeSpeechTranscriptor realTimeTranscriptor;
-        private SileroVadDetectorFactory vadDetectorFactory;
-        private WhisperFactory factory;
-        private WhisperSpeechTranscriptorFactory speechTranscriptorFactory;
-        private EchoSharpRealtimeTranscriptorFactory realTimeFactory;
-        CancellationTokenSource token = new CancellationTokenSource();
+        WaspiLoopbackAudioSource? waveloop;
+        Task? showTranscriptTask;
+        private IRealtimeSpeechTranscriptor? realTimeTranscriptor;
+        private SileroVadDetectorFactory? vadDetectorFactory;
+        private WhisperFactory? factory;
+        private WhisperSpeechTranscriptorFactory? speechTranscriptorFactory;
+        private EchoSharpRealtimeTranscriptorFactory? realTimeFactory;
+        private CancellationTokenSource? token;
+        private WhisperConfiguration? currentConfiguration;
+
+        private readonly IReadOnlyList<ModelOption> modelOptions = new List<ModelOption>
+        {
+            new("Tiny", GgmlType.Tiny),
+            new("Base", GgmlType.Base),
+            new("Small", GgmlType.Small),
+            new("Medium", GgmlType.Medium),
+            new("Large V2", GgmlType.LargeV2)
+        };
 
         public Form1()
         {
             InitializeComponent();
-            LoadTask = LoadModels();
+            InitializeConfigurationControls();
         }
 
-        public async Task LoadModels()
+        private void InitializeConfigurationControls()
         {
+            statusLabel.Text = "Status: Idle";
+
+            modelComboBox.DisplayMember = nameof(ModelOption.DisplayName);
+            modelComboBox.ValueMember = nameof(ModelOption.ModelType);
+            foreach (var option in modelOptions)
+            {
+                modelComboBox.Items.Add(option);
+            }
+            modelComboBox.SelectedItem = modelOptions.First(option => option.ModelType == GgmlType.Medium);
+
+            threadsNumeric.Value = Math.Max(1, Environment.ProcessorCount - 1);
+            temperatureNumeric.Value = 0.2M;
+            beamSizeNumeric.Value = 5;
+            bestOfNumeric.Value = 1;
+            vadThresholdNumeric.Value = 0.5M;
+            vadGapNumeric.Value = 0.15M;
+            translateCheckBox.Checked = false;
+            autoDetectLanguageCheckBox.Checked = false;
+            autodetectOnceCheckBox.Checked = false;
+            partialResultsCheckBox.Checked = true;
+            tokenDetailsCheckBox.Checked = true;
+            languageTextBox.Text = CultureInfo.CurrentCulture.Name;
+        }
+
+        private async Task EnsureTranscriptionConfiguredAsync()
+        {
+            var configuration = BuildConfigurationFromUi();
+
+            if (realTimeTranscriptor != null && currentConfiguration.HasValue && currentConfiguration.Value.Equals(configuration))
+            {
+                return;
+            }
+
+            DisposeFactories();
+
+            statusLabel.Text = "Status: Loading voice activity detector...";
             if (!Directory.Exists("models"))
             {
                 Directory.CreateDirectory("models");
@@ -49,94 +91,282 @@ namespace liveTranscribe
             }
             vadDetectorFactory = new SileroVadDetectorFactory(new SileroVadOptions(sileroOnnxPath)
             {
-                Threshold = 0f, // The threshold for Silero VAD. The default is 0.5f.
-                ThresholdGap = 0f, // The threshold gap for Silero VAD. The default is 0.15f.
+                Threshold = configuration.VadThreshold,
+                ThresholdGap = configuration.VadThresholdGap,
             });
-            var ggmlModelPath = "models/ggml-Medium.bin";
+
+            var ggmlModelPath = $"models/ggml-{configuration.ModelType}.bin";
             if (!File.Exists(ggmlModelPath))
             {
-                using var modelStream = await WhisperGgmlDownloader.Default.GetGgmlModelAsync(GgmlType.Medium);
+                statusLabel.Text = $"Status: Downloading {configuration.ModelType} model...";
+                using var modelStream = await WhisperGgmlDownloader.Default.GetGgmlModelAsync(configuration.ModelType);
                 using var fileWriter = File.OpenWrite(ggmlModelPath);
                 await modelStream.CopyToAsync(fileWriter);
             }
+
+            statusLabel.Text = "Status: Initializing Whisper...";
             factory = WhisperFactory.FromPath(ggmlModelPath);
-            speechTranscriptorFactory = new WhisperSpeechTranscriptorFactory(factory.CreateBuilder().WithTranslate().WithLanguageDetection());
+            var processorBuilder = factory.CreateBuilder();
+
+            if (configuration.Threads > 0)
+            {
+                processorBuilder = processorBuilder.WithThreads(configuration.Threads);
+            }
+
+            processorBuilder = processorBuilder.WithTemperature(configuration.Temperature);
+
+            if (!string.IsNullOrWhiteSpace(configuration.Prompt))
+            {
+                processorBuilder = processorBuilder.WithPrompt(configuration.Prompt);
+            }
+
+            if (configuration.Translate)
+            {
+                processorBuilder = processorBuilder.WithTranslate();
+            }
+
+            if (configuration.UseLanguageDetection)
+            {
+                processorBuilder = processorBuilder.WithLanguageDetection();
+            }
+            else
+            {
+                processorBuilder = processorBuilder.WithLanguage(configuration.LanguageCode);
+            }
+
+            if (configuration.BeamSize > 1)
+            {
+                var beamBuilder = processorBuilder.WithBeamSearchSamplingStrategy();
+                if (beamBuilder is BeamSearchSamplingStrategyBuilder beamSearchSamplingStrategyBuilder)
+                {
+                    beamSearchSamplingStrategyBuilder.WithBeamSize(configuration.BeamSize);
+                }
+                processorBuilder = beamBuilder.ParentBuilder;
+            }
+            else
+            {
+                var greedyBuilder = processorBuilder.WithGreedySamplingStrategy();
+                if (greedyBuilder is GreedySamplingStrategyBuilder greedySamplingStrategyBuilder)
+                {
+                    greedySamplingStrategyBuilder.WithBestOf(configuration.BestOf);
+                }
+                processorBuilder = greedyBuilder.ParentBuilder;
+            }
+
+            speechTranscriptorFactory = new WhisperSpeechTranscriptorFactory(processorBuilder);
 
             realTimeFactory = new EchoSharpRealtimeTranscriptorFactory(speechTranscriptorFactory, vadDetectorFactory, echoSharpOptions: new EchoSharpRealtimeOptions()
             {
-                ConcatenateSegmentsToPrompt = false // Flag to concatenate segments to prompt when new segment is recognized (for the whole session)
+                ConcatenateSegmentsToPrompt = false
             });
 
             realTimeTranscriptor = realTimeFactory.Create(new RealtimeSpeechTranscriptorOptions()
             {
-                AutodetectLanguageOnce = false, // Flag to detect the language only once or for each segment
-                IncludeSpeechRecogizingEvents = true, // Flag to include speech recognizing events (RealtimeSegmentRecognizing)
-                RetrieveTokenDetails = true, // Flag to retrieve token details
-                LanguageAutoDetect = false, // Flag to auto-detect the language
-                Language = new CultureInfo("en-US"), // Language to use for transcription
+                AutodetectLanguageOnce = configuration.AutodetectLanguageOnce,
+                IncludeSpeechRecogizingEvents = configuration.IncludeRecognizingEvents,
+                RetrieveTokenDetails = configuration.RetrieveTokenDetails,
+                LanguageAutoDetect = configuration.UseLanguageDetection,
+                Language = configuration.LanguageCulture,
+                Prompt = configuration.Prompt
             });
+
+            currentConfiguration = configuration;
+            statusLabel.Text = "Status: Ready";
         }
 
         private async void button1_Click(object sender, EventArgs e)
         {
-            await LoadTask;
-            if (waveloop == null)
-            {
+            startButton.Enabled = false;
+            stopButton.Enabled = false;
 
+            try
+            {
+                await EnsureTranscriptionConfiguredAsync();
+
+                if (waveloop != null)
+                {
+                    stopButton.Enabled = true;
+                    return;
+                }
+
+                token?.Dispose();
+                token = new CancellationTokenSource();
 
                 waveloop = new WaspiLoopbackAudioSource();
-                //waveloop = new MicrophoneInputSource();
+                transcriptTextBox.Clear();
+
+                stopButton.Enabled = true;
 
                 async Task ShowTranscriptAsync()
                 {
-                    await foreach (var transcription in realTimeTranscriptor.TranscribeAsync(waveloop, token.Token))
+                    try
                     {
-                        var eventType = transcription.GetType().Name;
-                        this.Invoke(new Action(() => label1.Text = eventType));
-
-                        var textToWrite = transcription switch
+                        await foreach (var transcription in realTimeTranscriptor!.TranscribeAsync(waveloop, token.Token))
                         {
-                            RealtimeSegmentRecognized segmentRecognized => $"{segmentRecognized.Segment.StartTime}-{segmentRecognized.Segment.StartTime + segmentRecognized.Segment.Duration}:{segmentRecognized.Segment.Text}",
-                            RealtimeSegmentRecognizing segmentRecognizing => $"{segmentRecognizing.Segment.StartTime}-{segmentRecognizing.Segment.StartTime + segmentRecognizing.Segment.Duration}:{segmentRecognizing.Segment.Text}",
-                            RealtimeSessionStarted sessionStarted => $"SessionId: {sessionStarted.SessionId}",
-                            RealtimeSessionStopped sessionStopped => $"SessionId: {sessionStopped.SessionId}",
-                            _ => string.Empty
-                        };
-                        this.Invoke(new Action(() => label2.Text = textToWrite));
+                            switch (transcription)
+                            {
+                                case RealtimeSessionStarted sessionStarted:
+                                    Invoke(() => statusLabel.Text = $"Status: Session {sessionStarted.SessionId} started");
+                                    break;
+                                case RealtimeSessionStopped sessionStopped:
+                                    Invoke(() => statusLabel.Text = $"Status: Session {sessionStopped.SessionId} stopped");
+                                    break;
+                                case RealtimeSegmentRecognizing segmentRecognizing:
+                                    Invoke(() =>
+                                    {
+                                        if (partialResultsCheckBox.Checked)
+                                        {
+                                            statusLabel.Text = $"Status: Recognizing… {segmentRecognizing.Segment.Text}";
+                                        }
+                                    });
+                                    break;
+                                case RealtimeSegmentRecognized segmentRecognized:
+                                    Invoke(() =>
+                                    {
+                                        statusLabel.Text = "Status: Segment recognized";
+                                        transcriptTextBox.AppendText($"[{segmentRecognized.Segment.StartTime:hh\\:mm\\:ss}-{(segmentRecognized.Segment.StartTime + segmentRecognized.Segment.Duration):hh\\:mm\\:ss}] {segmentRecognized.Segment.Text}{Environment.NewLine}");
+                                        transcriptTextBox.SelectionStart = transcriptTextBox.TextLength;
+                                        transcriptTextBox.ScrollToCaret();
+                                    });
+                                    break;
+                            }
+                        }
                     }
-                    this.Invoke(new Action(() => label2.Text = "Completed"));
+                    catch (OperationCanceledException)
+                    {
+                        Invoke(() => statusLabel.Text = "Status: Cancelled");
+                    }
+                    finally
+                    {
+                        Invoke(() => stopButton.Enabled = false);
+                        Invoke(() => startButton.Enabled = true);
+                    }
                 }
-                ;
-                waveloop.StartRecording();
-                showTranscriptTask = ShowTranscriptAsync();
 
+                waveloop.StartRecording();
+                statusLabel.Text = "Status: Recording";
+                showTranscriptTask = ShowTranscriptAsync();
+            }
+            catch (Exception ex)
+            {
+                DisposeFactories();
+                statusLabel.Text = $"Status: Error - {ex.Message}";
+                startButton.Enabled = true;
+                stopButton.Enabled = false;
             }
         }
 
         private void button2_Click(object sender, EventArgs e)
         {
-            if (waveloop != null)
-            {
-                MessageBox.Show(waveloop.Duration.ToString());
-                waveloop.StopRecording();
-                waveloop.Dispose();
-                waveloop = null;
-                token.Cancel();
-            }
+            StopTranscription();
         }
 
         protected override void OnFormClosed(FormClosedEventArgs e)
         {
             base.OnFormClosed(e);
+            StopTranscription();
+            DisposeFactories();
+            token?.Dispose();
+            token = null;
+        }
+
+        private WhisperConfiguration BuildConfigurationFromUi()
+        {
+            if (modelComboBox.SelectedItem is not ModelOption modelOption)
+            {
+                throw new InvalidOperationException("Please select a model");
+            }
+
+            var languageCode = languageTextBox.Text.Trim();
+            CultureInfo culture;
+            try
+            {
+                culture = string.IsNullOrWhiteSpace(languageCode)
+                    ? CultureInfo.GetCultureInfo("en-US")
+                    : CultureInfo.GetCultureInfo(languageCode);
+            }
+            catch (CultureNotFoundException ex)
+            {
+                throw new InvalidOperationException("Invalid language code", ex);
+            }
+
+            var prompt = string.IsNullOrWhiteSpace(promptTextBox.Text) ? null : promptTextBox.Text;
+
+            return new WhisperConfiguration(
+                modelOption.ModelType,
+                translateCheckBox.Checked,
+                autoDetectLanguageCheckBox.Checked,
+                culture.Name,
+                culture,
+                (float)temperatureNumeric.Value,
+                (int)beamSizeNumeric.Value,
+                (int)bestOfNumeric.Value,
+                (float)vadThresholdNumeric.Value,
+                (float)vadGapNumeric.Value,
+                partialResultsCheckBox.Checked,
+                autodetectOnceCheckBox.Checked,
+                tokenDetailsCheckBox.Checked,
+                (int)threadsNumeric.Value,
+                prompt
+            );
+        }
+
+        private void StopTranscription()
+        {
+            token?.Cancel();
+
             if (waveloop != null)
             {
                 waveloop.StopRecording();
                 waveloop.Dispose();
+                waveloop = null;
+            }
 
-                factory.Dispose();
-                speechTranscriptorFactory.Dispose();
-    }
+            token?.Dispose();
+            token = null;
+
+            showTranscriptTask = null;
+
+            stopButton.Enabled = false;
+            startButton.Enabled = true;
+            statusLabel.Text = "Status: Idle";
         }
+
+        private void DisposeFactories()
+        {
+            speechTranscriptorFactory?.Dispose();
+            speechTranscriptorFactory = null;
+
+            factory?.Dispose();
+            factory = null;
+
+            vadDetectorFactory = null;
+            realTimeFactory = null;
+            realTimeTranscriptor = null;
+            currentConfiguration = null;
+        }
+
+        private sealed record ModelOption(string DisplayName, GgmlType ModelType)
+        {
+            public override string ToString() => DisplayName;
+        }
+
+        private readonly record struct WhisperConfiguration(
+            GgmlType ModelType,
+            bool Translate,
+            bool UseLanguageDetection,
+            string LanguageCode,
+            CultureInfo LanguageCulture,
+            float Temperature,
+            int BeamSize,
+            int BestOf,
+            float VadThreshold,
+            float VadThresholdGap,
+            bool IncludeRecognizingEvents,
+            bool AutodetectLanguageOnce,
+            bool RetrieveTokenDetails,
+            int Threads,
+            string? Prompt);
 
     }
 }

--- a/liveTranscribe/Form1.resx
+++ b/liveTranscribe/Form1.resx
@@ -117,7 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="notifyIcon1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/liveTranscribe/WaspiLoopbackAudioSource.cs
+++ b/liveTranscribe/WaspiLoopbackAudioSource.cs
@@ -1,51 +1,21 @@
-﻿using EchoSharp.Audio;
+using EchoSharp.Audio;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.IO;
 
 namespace liveTranscribe
 {
     internal class WaspiLoopbackAudioSource : AwaitableWaveFileSource
     {
-        WasapiLoopbackCapture waveloop;
-        WaveFormat format;
-        WaveFormat inFormat;
-        private WaveFileWriter? waveFile;
+        private readonly WasapiLoopbackCapture waveloop;
+        private readonly WaveFormat inputFormat;
 
-        public byte[] ToPCM16(byte[] buffer, int length, WaveFormat format)
+        public WaspiLoopbackAudioSource()
+            : base()
         {
-            if (length == 0)
-            {
-                return new byte[0];
-            }
-
-            using var memStream = new MemoryStream(buffer, 0, length);
-            using var inputStream = new RawSourceWaveStream(memStream, format);
-
-            var convertedPCM = new SampleToWaveProvider16(
-                    new WdlResamplingSampleProvider(
-                        new WaveToSampleProvider(inputStream), 16000)
-                );
-
-            byte[] convertedBuffer = new byte[length];
-
-            using var stream = new MemoryStream();
-            int read;
-
-            while ((read = convertedPCM.Read(convertedBuffer, 0, length)) > 0)
-                stream.Write(convertedBuffer, 0, read);
-
-            return stream.ToArray();
-        }
-
-        public WaspiLoopbackAudioSource() : base(aggregationStrategy: DefaultChannelAggregationStrategies.SelectChannel(0))
-        {
-            
             waveloop = new WasapiLoopbackCapture();
+            inputFormat = waveloop.WaveFormat;
 
             Initialize(new AudioSourceHeader()
             {
@@ -53,26 +23,59 @@ namespace liveTranscribe
                 Channels = 1,
                 SampleRate = 16000
             });
-            
-            
-            //format = new WaveFormat(16000, 2);
-            inFormat = WaveFormat.CreateIeeeFloatWaveFormat(48000, 2);
-            
+
             waveloop.DataAvailable += Waveloop_DataAvailable;
             waveloop.RecordingStopped += Waveloop_RecordingStopped;
+        }
+
+        private byte[] ToPcm16(byte[] buffer, int length)
+        {
+            if (length == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            using var memStream = new MemoryStream(buffer, 0, length);
+            using var inputStream = new RawSourceWaveStream(memStream, inputFormat);
+
+            ISampleProvider sampleProvider = new WaveToSampleProvider(inputStream);
+
+            if (inputFormat.Channels > 1)
+            {
+                var stereoToMono = new StereoToMonoSampleProvider(sampleProvider)
+                {
+                    LeftVolume = 0.5f,
+                    RightVolume = 0.5f
+                };
+                sampleProvider = stereoToMono;
+            }
+
+            if (sampleProvider.WaveFormat.SampleRate != 16000)
+            {
+                sampleProvider = new WdlResamplingSampleProvider(sampleProvider, 16000);
+            }
+
+            var convertedProvider = new SampleToWaveProvider16(sampleProvider);
+            var convertedBuffer = new byte[Math.Max(convertedProvider.WaveFormat.AverageBytesPerSecond / 4, 2048)];
+
+            using var stream = new MemoryStream();
+            int read;
+            while ((read = convertedProvider.Read(convertedBuffer, 0, convertedBuffer.Length)) > 0)
+            {
+                stream.Write(convertedBuffer, 0, read);
+            }
+
+            return stream.ToArray();
         }
 
         public void StartRecording()
         {
             waveloop.StartRecording();
-            //waveFile = new WaveFileWriter("testStream.wav", format);
         }
 
         public void StopRecording()
         {
             waveloop.StopRecording();
-            //waveFile?.Flush();
-            //waveFile?.Close();
         }
 
         protected override void Dispose(bool disposing)
@@ -88,12 +91,11 @@ namespace liveTranscribe
 
         private void Waveloop_DataAvailable(object? sender, WaveInEventArgs e)
         {
-
-
-
-            var buffer = ToPCM16(e.Buffer, e.BytesRecorded, inFormat);
-            //waveFile?.Write(buffer, 0, buffer.Length);
-            WriteData(buffer.AsMemory(0, buffer.Length));
+            var buffer = ToPcm16(e.Buffer, e.BytesRecorded);
+            if (buffer.Length > 0)
+            {
+                WriteData(buffer.AsMemory());
+            }
         }
 
         private void Waveloop_RecordingStopped(object? sender, StoppedEventArgs e)
@@ -102,6 +104,7 @@ namespace liveTranscribe
             {
                 throw e.Exception;
             }
+
             Flush();
         }
     }


### PR DESCRIPTION
## Summary
- add rich UI controls for selecting Whisper model parameters, VAD thresholds, and prompts before starting transcription
- rework transcription startup logic to rebuild factories only when options change and surface status updates during live recognition
- improve loopback audio conversion by resampling/averaging channels based on the actual capture format for cleaner PCM16 input

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68cfa6c11c7c83279fcac137e9d0b762